### PR TITLE
Implement version checking towards GitHub

### DIFF
--- a/Gray.xcodeproj/project.pbxproj
+++ b/Gray.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2AECAC775C01910CCBFAD88E /* libPods-Gray.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C02BDE925690A5BBA8E6D44 /* libPods-Gray.a */; };
 		BD111046215CEB240002D537 /* Shell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD111045215CEB240002D537 /* Shell.swift */; };
+		BD1D9545215E435F003ABBCF /* VersionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1D9544215E435F003ABBCF /* VersionController.swift */; };
 		BD30844A215C198D002A9349 /* ApplicationsLogicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD308449215C198D002A9349 /* ApplicationsLogicController.swift */; };
 		BD67CE0E215BF15F00216FDB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD67CE0D215BF15F00216FDB /* AppDelegate.swift */; };
 		BD67CE10215BF16100216FDB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD67CE0F215BF16100216FDB /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 		8925482688825713455FEF24 /* Pods-Gray.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Gray.release.xcconfig"; path = "Target Support Files/Pods-Gray/Pods-Gray.release.xcconfig"; sourceTree = "<group>"; };
 		9C02BDE925690A5BBA8E6D44 /* libPods-Gray.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Gray.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD111045215CEB240002D537 /* Shell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shell.swift; sourceTree = "<group>"; };
+		BD1D9544215E435F003ABBCF /* VersionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionController.swift; sourceTree = "<group>"; };
 		BD308449215C198D002A9349 /* ApplicationsLogicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsLogicController.swift; sourceTree = "<group>"; };
 		BD67CE0A215BF15F00216FDB /* Gray.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gray.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD67CE0D215BF15F00216FDB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				BD9D3D79215C2D3F00233333 /* Applications */,
 				BD67CE0D215BF15F00216FDB /* AppDelegate.swift */,
 				BD111045215CEB240002D537 /* Shell.swift */,
+				BD1D9544215E435F003ABBCF /* VersionController.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -227,6 +230,7 @@
 				BD67CE1C215BF4FE00216FDB /* ApplicationsViewController.swift in Sources */,
 				BD67CE0E215BF15F00216FDB /* AppDelegate.swift in Sources */,
 				BD30844A215C198D002A9349 /* ApplicationsLogicController.swift in Sources */,
+				BD1D9545215E435F003ABBCF /* VersionController.swift in Sources */,
 				BD9D3D7D215C2D7100233333 /* ApplicationView.swift in Sources */,
 				BD111046215CEB240002D537 /* Shell.swift in Sources */,
 				BD9D3D7F215C30B000233333 /* ApplicationCollectionViewController.swift in Sources */,

--- a/Resources/Base.lproj/MainMenu.xib
+++ b/Resources/Base.lproj/MainMenu.xib
@@ -25,6 +25,12 @@
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Check for Updates..." id="1Ic-d9-XXx">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="checkForNewVersion:" target="Voe-Tx-rLC" id="Cs0-h9-kOF"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
                             <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2,12 +2,15 @@ import Cocoa
 import Vaccine
 
 @NSApplicationMain
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, VersionControllerDelegate {
+  let versionController = VersionController()
   var window: NSWindow?
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     Injection.load(then: loadApplication)
       .add(observer: self, with: #selector(injected(_:)))
+    versionController.delegate = self
+    checkForNewVersion(nil)
   }
 
   @objc private func loadApplication() {
@@ -30,13 +33,64 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     window.minSize = .init(width: 320, height: 320)
-
     window.makeKeyAndOrderFront(nil)
     self.window = window
   }
 
+  // MARK: - Injection
+
   @objc open func injected(_ notification: Notification) {
     loadApplication()
+  }
+
+  @IBAction func checkForNewVersion(_ sender: Any?) {
+    versionController.checkForNewVersion { [weak self] foundNewVersion in
+      guard let strongSelf = self else { return }
+      switch foundNewVersion {
+      case true:
+        let version = strongSelf.versionController.currentVersion()
+        strongSelf.showNewVersionDialog(version: version) { openGitHub in
+          if openGitHub {
+            let url = URL(string: "https://github.com/zenangst/Gray/releases/tag/\(version)")!
+            NSWorkspace.shared.open(url)
+          }
+        }
+      case false:
+        if sender != nil {
+          strongSelf.showNoNewUpdates()
+        }
+      }
+    }
+  }
+
+  private func showNewVersionDialog(version: String, handler completion : (Bool)->Void) {
+    let alert = NSAlert()
+    alert.messageText = "A new version is available."
+    alert.informativeText = "Version \(version) is available for download on GitHub."
+    alert.alertStyle = .informational
+    alert.addButton(withTitle: "Open GitHub")
+    alert.addButton(withTitle: "OK")
+    completion(alert.runModal() == .alertFirstButtonReturn)
+  }
+
+  private func showNoNewUpdates() {
+    let alert = NSAlert()
+    alert.messageText = "You’re up-to-date!"
+    alert.informativeText = "Gray \(versionController.currentVersion()) is currently the newest version available."
+    alert.alertStyle = .informational
+    alert.addButton(withTitle: "OK")
+    alert.runModal()
+  }
+
+  // MARK: - VersionControllerDelegate
+
+  func versionController(_ controller: VersionController, foundNewVersion version: String) {
+    showNewVersionDialog(version: version) { openGitHub in
+      if openGitHub {
+        let url = URL(string: "https://github.com/zenangst/Gray/releases/tag/\(version)")!
+        NSWorkspace.shared.open(url)
+      }
+    }
   }
 }
 

--- a/Sources/VersionController.swift
+++ b/Sources/VersionController.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+protocol VersionControllerDelegate: class {
+  func versionController(_ controller: VersionController, foundNewVersion version: String)
+}
+
+class VersionController {
+  weak var delegate: VersionControllerDelegate?
+  let urlSession = URLSession.shared
+
+  func currentVersion() -> String {
+    return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
+  }
+
+  func checkForNewVersion(then handler: @escaping (Bool) -> Void) {
+    let url = URL(string: "https://raw.githubusercontent.com/zenangst/Gray/master/.current-version")!
+    let task = URLSession.shared.dataTask(with: url) {
+      [weak self] (data, response, error) in
+      guard let strongSelf = self,
+        let data = data,
+        let body = String.init(data: data, encoding: .utf8) else {
+          DispatchQueue.main.async { handler(false) }
+          return
+      }
+
+      let newVersion = body.replacingOccurrences(of: "\n", with: "")
+
+      if strongSelf.currentVersion() != newVersion,
+        newVersion.compare(strongSelf.currentVersion(), options: .numeric) == .orderedDescending {
+        DispatchQueue.main.async {
+          strongSelf.delegate?.versionController(strongSelf, foundNewVersion: newVersion)
+        }
+      } else {
+        DispatchQueue.main.async { handler(false) }
+      }
+    }
+    task.resume()
+  }
+}


### PR DESCRIPTION
This PR implements version updates using GitHub as the source of truth.
It fetches `.current-version` from the `master`-branch and checks that number towards the application bundle identifier. If a new version is found, the app will show an update dialog.

<img width="420" alt="screen shot 2018-09-28 at 13 42 57" src="https://user-images.githubusercontent.com/57446/46207295-2b284380-c327-11e8-8d3e-05d68ee66699.png">

If no new version is found, the user will be presented with this kind of message:

<img width="420" alt="screen shot 2018-09-28 at 14 02 48" src="https://user-images.githubusercontent.com/57446/46207316-3aa78c80-c327-11e8-8265-58497d56730a.png">

Checking for new updates is also available via the menu bar, like you would expect:

<img width="266" alt="screen shot 2018-09-28 at 14 04 01" src="https://user-images.githubusercontent.com/57446/46207354-69256780-c327-11e8-94a9-8dd03bf87d9f.png">
