### PR TITLE
Create queue on Shell instead of inside launch command

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/Shell.swift
+++ b/Sources/Shell.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 class Shell {
+  let queue = DispatchQueue(label: "shell-execution")
+
   @discardableResult func execute(command: String,
                                   arguments: [String] = [],
                                   at path: String = ".") throws -> String {
@@ -15,12 +17,12 @@ class Shell {
   private func launch(_ process: Process,
                       command: String,
                       withShell: String = "/bin/bash") throws -> String {
-    let queue = DispatchQueue(label: "shell-execution")
     let pipe = Pipe()
     var output = Data()
 
-    pipe.fileHandleForReading.readabilityHandler = { handler in
-      queue.async {
+    pipe.fileHandleForReading.readabilityHandler = { [weak self] handler in
+      guard let strongSelf = self else { return }
+      strongSelf.queue.async {
         let data = handler.availableData
         output.append(data)
       }


### PR DESCRIPTION
To avoid recursion, the `queue` is now created on the `Shell` class instead of inside the `launch` function.