### PR TITLE
Fix bug with Mail not changing appearance.

### DIFF
--- a/Sources/Applications/ApplicationsLogicController.swift
+++ b/Sources/Applications/ApplicationsLogicController.swift
@@ -77,11 +77,11 @@ class ApplicationsLogicController {
       var resolvedAppPreferenceUrl = appPreferenceUrl
       var applicationPlist: NSDictionary? = nil
 
-      if let plist = NSDictionary.init(contentsOfFile: appPreferenceUrl.path) {
-        applicationPlist = plist
-      } else if let plist = NSDictionary.init(contentsOfFile: appContainerPreferenceUrl.path) {
+      if let plist = NSDictionary.init(contentsOfFile: appContainerPreferenceUrl.path) {
         applicationPlist = plist
         resolvedAppPreferenceUrl = appContainerPreferenceUrl
+      } else if let plist = NSDictionary.init(contentsOfFile: appPreferenceUrl.path) {
+        applicationPlist = plist
       }
 
       guard let resolvedPlist = applicationPlist else { continue }


### PR DESCRIPTION
Change the order by how plist locations are prioritized. Containers are now used as the new default and `~/Library/Preferences` is the fallback. This fixes issues with apps like Mail.

Fixes https://github.com/zenangst/Gray/issues/7