### PR TITLE
Exclude Electron apps

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.1</string>
+	<string>0.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Applications/Logic/ApplicationsLogicController.swift
@@ -73,6 +73,12 @@ class ApplicationsLogicController {
         let bundleIdentifier = plist.value(forPlistKey: .bundleIdentifier),
         let bundleName = plist.value(forPlistKey: .bundleName) else { continue }
 
+      // Exclude Electron apps
+      let electronPath = "\(url.path)/Contents/Frameworks/Electron Framework.framework"
+      if FileManager.default.fileExists(atPath: electronPath) {
+        continue
+      }
+
       let suffix = "Preferences/\(bundleIdentifier).plist"
       let appPreferenceUrl = libraryDirectory.appendingPathComponent(suffix)
       let appContainerPreferenceUrl = libraryDirectory.appendingPathComponent("Containers/\(bundleIdentifier)/Data/Library/\(suffix)")


### PR DESCRIPTION
Electron apps are now excluded from the list of applications that can change appearance.

Fixes https://github.com/zenangst/Gray/issues/18