### PR TITLE
Exclude VMWare

### DIFF
--- a/Gray.xcodeproj/project.pbxproj
+++ b/Gray.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp -f -R ${BUILT_PRODUCTS_DIR}/${APPLICATION_NAME} /Applications\n";
+			shellScript = "cp -f -R ${CODESIGNING_FOLDER_PATH} /Applications\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This PR removes VMWare from the list of applications that you can change the appearance of.
It has been known to cause issues for people so it would be good to prevent that entirely until VMWare builds their app and links it against the latest SDK.

It also fixes the build script, now it will only copy the application and not everything else in the build folder.

See #42 for reference