### PR TITLE
Adds an NSMenu to the ApplicationGridView

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.1</string>
+	<string>0.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.8.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Features/Applications/View Controllers/ApplicationsViewController.swift
+++ b/Sources/Features/Applications/View Controllers/ApplicationsViewController.swift
@@ -8,7 +8,7 @@ protocol ApplicationsViewControllerDelegate: class {
                                  application: Application)
 }
 
-class ApplicationsViewController: NSViewController, NSCollectionViewDelegate {
+class ApplicationsViewController: NSViewController, NSCollectionViewDelegate, ApplicationGridViewDelegate {
   enum State {
     case view([Application])
   }
@@ -89,7 +89,20 @@ class ApplicationsViewController: NSViewController, NSCollectionViewDelegate {
     completion(alert.runModal() == .alertFirstButtonReturn)
   }
 
+  // MARK: - ApplicationGridViewDelegate
+
+  func applicationView(_ view: ApplicationGridView, didResetApplication currentAppearance: Application.Appearance?) {
+    guard let indexPath = collectionView.indexPath(for: view) else { return }
+
+    let application = dataSource.model(at: indexPath)
+    toggle(.system, for: application)
+  }
+
   // MARK: - NSCollectionViewDelegate
+
+  func collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
+    (item as? ApplicationGridView)?.delegate = self
+  }
 
   func collectionView(_ collectionView: NSCollectionView, didSelectItemsAt indexPaths: Set<IndexPath>) {
     guard let indexPath = indexPaths.first,

--- a/Sources/Features/Applications/Views/ApplicationGridView.swift
+++ b/Sources/Features/Applications/Views/ApplicationGridView.swift
@@ -2,7 +2,7 @@ import Cocoa
 import UserInterface
 
 protocol ApplicationGridViewDelegate: class {
-  func applicationView(_ view: ApplicationGridView, didClickSegmentedControl segmentedControl: NSSegmentedControl)
+  func applicationView(_ view: ApplicationGridView, didResetApplication currentAppearance: Application.Appearance?)
 }
 
 class ApplicationGridView: NSCollectionViewItem {
@@ -21,6 +21,10 @@ class ApplicationGridView: NSCollectionViewItem {
 
   override func viewDidLoad() {
     super.viewDidLoad()
+
+    let menu = NSMenu()
+    menu.addItem(NSMenuItem(title: "Reset", action: #selector(resetApplication), keyEquivalent: ""))
+    view.menu = menu
 
     view.layer?.backgroundColor = NSColor.white.cgColor
     view.layer?.cornerRadius = 20
@@ -64,6 +68,10 @@ class ApplicationGridView: NSCollectionViewItem {
 
     guard let currentAppearance = currentAppearance else { return }
     update(with: currentAppearance)
+  }
+
+  @objc func resetApplication() {
+    delegate?.applicationView(self, didResetApplication: currentAppearance)
   }
 
   func update(with appearance: Application.Appearance, duration: TimeInterval = 0, then handler: (() -> Void)? = nil) {


### PR DESCRIPTION
Enable resetting application by using the second mouse button to open a small menu on the application view.

Resetting an application runs the follwing command:

```fish
/usr/bin/killall -u $USER cfprefsd
defaults delete \(application.bundleIdentifier) NSRequiresAquaSystemAppearance
defaults read \(application.bundleIdentifier) NSRequiresAquaSystemAppearance \(application.preferencesUrl.path)
```