### PR TITLE
Refactor ApplicationsLogicController to scan additional folders

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.0</string>
+	<string>0.9.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
The application logic controller will now scan the following folders
- Applications
- Applications/Utilities
- Applications/Xcode.app/Contents/Applications

The only app exception in the list is Finder which is added with an absolute path.

First attempt at solving #45 