### PR TITLE
Use try/catch instead of try

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://github.com/zenangst/Gray/blob/master/Resources/Assets.xcassets/AppIcon.appiconset/icon_256x256.png?raw=true" alt="Gray Icon" align="right" />
 
-Current version: 0.9.1 [[Download](https://github.com/zenangst/Gray/releases/download/0.9.1/Gray.zip)]
+Current version: 0.9.2 [[Download](https://github.com/zenangst/Gray/releases/download/0.9.2/Gray.zip)]
 
 Ever wanted to have light and dark apps live side-by-side in harmony? Well, now you can. With **Gray** you can pick between the light appearance and the dark appearance on a per-app basis with the click of a button.
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.1</string>
+	<string>0.9.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -18,11 +18,12 @@ class ApplicationsLogicController {
       applicationUrls.append(URL(string: "file:///System/Library/CoreServices/Finder.app")!)
       for url in try applicationLocations() {
         guard FileManager.default.fileExists(atPath: url.path) else { continue }
-
-        let urls = try FileManager.default.contentsOfDirectory(at: url,
-                                                               includingPropertiesForKeys: nil,
-                                                               options: .skipsHiddenFiles)
-        applicationUrls.append(contentsOf: urls)
+        do {
+          let urls = try FileManager.default.contentsOfDirectory(at: url,
+                                                                 includingPropertiesForKeys: nil,
+                                                                 options: .skipsHiddenFiles)
+          applicationUrls.append(contentsOf: urls)
+        } catch {}
       }
 
       let applications = try parseApplicationUrls(applicationUrls, excludedBundles: excludedBundles)
@@ -101,7 +102,8 @@ class ApplicationsLogicController {
     return directories
   }
 
-  private func parseApplicationUrls(_ appUrls: [URL], excludedBundles: [String] = []) throws -> [Application] {
+  private func parseApplicationUrls(_ appUrls: [URL],
+                                    excludedBundles: [String] = []) throws -> [Application] {
     var applications = [Application]()
     let shell = Shell()
     let sip = shell.execute(command: "csrutil status").contains("enabled")
@@ -144,8 +146,7 @@ class ApplicationsLogicController {
         NSDictionary.init(contentsOfFile: appContainerPreferenceUrl.path) == nil
 
       let app = Application(bundleIdentifier: bundleIdentifier,
-                            name: bundleName,
-                            url: url,
+                            name: bundleName, url: url,
                             preferencesUrl: resolvedAppPreferenceUrl,
                             appearance: applicationPlist?.appearance() ?? .system,
                             restricted: restricted)


### PR DESCRIPTION
This intends to fix a bug that the method throws when trying to parse the application folder. If it throws, no applications would be visible in the GUI.