### PR TITLE
Add several macOS (non-) default application locs

### DIFF
--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -104,7 +104,7 @@ class ApplicationsLogicController {
     // other non-default application directories
     directories.append("/System/Library/CoreServices") // Gray *hopefully* excludes any non-application bundles; this path will also include Finder, Stocks etc. and several miscellaneous system applications in subdirectory /System/Library/CoreServices/Applications
     directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Applications"))
-    directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Developer/Applications")
+    directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Developer/Applications"))
     directories.append(homeDirectory.appendingPathComponent("Library/Developer/Xcode/DerivedData")) // default location for subdirectories containing applications freshly built with Xcode                 
     directories.append("/Users/Shared/Applications")
 

--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -87,8 +87,26 @@ class ApplicationsLogicController {
                                                            in: .localDomainMask,
                                                            appropriateFor: nil,
                                                            create: false)
-    directories.append(applicationDirectory)
+    let applicationDirectoryU = try FileManager.default.url(for: .applicationDirectory,
+                                                           in: .userDomainMask,
+                                                           appropriateFor: nil,
+                                                           create: false)
+    let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+    
+    // macOS default Applications directories
+    directories.append(applicationDirectory) // including macOS default paths ./Utilities & ./Demos
+    directories.append(applicationDirectoryU) // including macOS default paths ./Utilities & ./Demos
+    directories.append(homeDirectory.appendingPathComponent("Developer/Applications"))
+    directories.append("/Developer/Applications")
+    directories.append("/Network/Applications") // including macOS default paths ./Utilities & ./Demos
+    directories.append("/Network/Developer/Applications")
+    
+    // other non-default application directories
+    directories.append("/System/Library/CoreServices") // Gray *hopefully* excludes any non-application bundles; this path will also include Finder, Stocks etc. and several miscellaneous system applications in subdirectory /System/Library/CoreServices/Applications
     directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Applications"))
+    directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Developer/Applications")
+    directories.append(homeDirectory.appendingPathComponent("Library/Developer/Xcode/DerivedData")) // default location for subdirectories containing applications freshly built with Xcode                 
+    directories.append("/Users/Shared/Applications")
 
     return directories
   }

--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -92,21 +92,26 @@ class ApplicationsLogicController {
                                                            appropriateFor: nil,
                                                            create: false)
     let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+    let applicationDirectoryD = URL(fileURLWithPath: "/Developer/Applications")
+    let applicationDirectoryN = URL(fileURLWithPath: "/Network/Applications")
+    let applicationDirectoryND = URL(fileURLWithPath: "/Network/Developer/Applications")
+    let coreServicesDirectory = URL(fileURLWithPath: "/System/Library/CoreServices")
+    let applicationDirectoryS = URL(fileURLWithPath: "/Users/Shared/Applications")
     
     // macOS default Applications directories
     directories.append(applicationDirectory) // including macOS default paths ./Utilities & ./Demos
     directories.append(applicationDirectoryU) // including macOS default paths ./Utilities & ./Demos
     directories.append(homeDirectory.appendingPathComponent("Developer/Applications"))
-    directories.append("/Developer/Applications")
-    directories.append("/Network/Applications") // including macOS default paths ./Utilities & ./Demos
-    directories.append("/Network/Developer/Applications")
+    directories.append(applicationDirectoryD)
+    directories.append(applicationDirectoryN) // including macOS default paths ./Utilities & ./Demos
+    directories.append(applicationDirectoryND)    
     
     // other non-default application directories
-    directories.append("/System/Library/CoreServices") // Gray *hopefully* excludes any non-application bundles; this path will also include Finder, Stocks etc. and several miscellaneous system applications in subdirectory /System/Library/CoreServices/Applications
+    directories.append(coreServicesDirectory) // Gray *hopefully* excludes any non-application bundles; this path will also include Finder, Stocks etc. and several miscellaneous system applications in subdirectory /System/Library/CoreServices/Applications
     directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Applications"))
     directories.append(applicationDirectory.appendingPathComponent("Xcode.app/Contents/Developer/Applications"))
     directories.append(homeDirectory.appendingPathComponent("Library/Developer/Xcode/DerivedData")) // default location for subdirectories containing applications freshly built with Xcode                 
-    directories.append("/Users/Shared/Applications")
+    directories.append(applicationDirectoryS)
 
     return directories
   }


### PR DESCRIPTION
Hope this isn't too much. Please see the in-code notes especially about `/System/Library/CoreServices`. There are lot of non-application bundles in there.

```
~/Applications
~/Developer/Applications
/Network/Applications
/Network/Developer/Applications
---
/System/Library/CoreServices # incl. ./Applications
/Applications/Xcode.app/Contents/Developer/Applications
~/Library/Developer/Xcode/DerivedData
/Users/Shared/Applications
```

Note: I'm not sure if passing the absolute POSIX path like that is OK in Swift; cf. e.g. `/Developer/Applications`. EDIT: fixed with third commit, but some trailing slashes are missing from paths output.