### PR TITLE
Improve/application parsing

### DIFF
--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -17,7 +17,6 @@ class ApplicationsLogicController {
       for path in try applicationLocations() {
         applicationUrls.append(contentsOf: recursiveParse(at: path))
       }
-      applicationUrls.append(URL(string: "file:///System/Library/CoreServices/Finder.app")!)
       let applications = try parseApplicationUrls(applicationUrls, excludedBundles: excludedBundles)
       handler(.view(applications))
     } catch {}

--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -194,7 +194,7 @@ class ApplicationsLogicController {
     let excludeKeywords = [
       "handler", "agent", "migration",
       "problem", "setup", "uiserver",
-      "install", "system image"]
+      "install", "system image", "escrow"]
 
     for keyword in excludeKeywords {
       if url.lastPathComponent.lowercased().contains(keyword) {
@@ -208,7 +208,7 @@ class ApplicationsLogicController {
     }
 
     // Exclude applications that don't have an icon file.
-    if plist.value(forPlistKey: .iconFile) == nil {
+    if plist.value(forPlistKey: .iconFile) == nil && url.path.contains("CoreServices")  {
       return true
     }
 

--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -145,6 +145,7 @@ class ApplicationsLogicController {
                                                        in: .userDomainMask,
                                                        appropriateFor: nil,
                                                        create: false)
+    var addedApplicationNames = [String]()
     for url in appUrls {
       let path = url.path
       let infoPath = "\(path)/Contents/Info.plist"
@@ -152,6 +153,7 @@ class ApplicationsLogicController {
         let plist = NSDictionary.init(contentsOfFile: infoPath),
         let bundleIdentifier = plist.value(forPlistKey: .bundleIdentifier),
         let bundleName = plist.value(forPlistKey: .bundleName),
+        !addedApplicationNames.contains(bundleName),
         !excludedBundles.contains(bundleIdentifier) else { continue }
 
       if shouldExcludeApplication(with: plist, applicationUrl: url) == true { continue }
@@ -181,6 +183,7 @@ class ApplicationsLogicController {
                             appearance: applicationPlist?.appearance() ?? .system,
                             restricted: restricted)
       applications.append(app)
+      addedApplicationNames.append(bundleName)
     }
     return applications.sorted(by: { $0.name.lowercased() < $1.name.lowercased() })
   }


### PR DESCRIPTION
- Removes special case for adding `Finder` to the list of applications
- Improves how applications are filtered out from the list of applications

Applications that don't show up on the list are excluded because of the following reasons.

- Their application name includes any of the excluded keywords

```swift
let excludeKeywords = [
  "handler", "agent", "migration",
  "problem", "setup", "uiserver",
  "install", "system image", "escrow"]
```

- The application is lacking an icon
- Uses Electron