### PR TITLE
Fix application without bundle name not showing up

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,5 @@ pod 'Blueprints'
 pod 'Differific'
 pod 'Family'
 pod 'UserInterface'
-pod 'Vaccine'
 
 target 'Gray'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,14 +3,12 @@ PODS:
   - Differific (0.5.2)
   - Family (0.6.8)
   - UserInterface (0.5.0)
-  - Vaccine (0.15.0)
 
 DEPENDENCIES:
   - Blueprints
   - Differific
   - Family
   - UserInterface
-  - Vaccine
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -18,15 +16,13 @@ SPEC REPOS:
     - Differific
     - Family
     - UserInterface
-    - Vaccine
 
 SPEC CHECKSUMS:
   Blueprints: bd8e23ee3b1ee9faa751ddb6e9cd82fef862ce9a
   Differific: b26ecab6daa1a2a93efeee41cec5e9593ced09bc
   Family: 8a5b1abbbb7ff8d1dab471f082a6fd81a2c1c5e5
   UserInterface: 54e15db9aceaec2b9686d00f471adb15d2598ea3
-  Vaccine: dcc3cb8a83d20ab1ab76f7324683b4d73079cda8
 
-PODFILE CHECKSUM: cc5e0a81b9c0eb7a8912c97a9ac152643c4403a3
+PODFILE CHECKSUM: 9b6f93d828aae511798d5dc18b356dca6da71a1a
 
 COCOAPODS: 1.6.0.beta.2

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.5</string>
+	<string>0.9.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -1,5 +1,4 @@
 import Cocoa
-import Vaccine
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, VersionControllerDelegate {
@@ -8,9 +7,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, VersionControllerDelegate {
   weak var window: NSWindow?
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
-    Injection.load(then: self.loadApplication)
-      .add(observer: self, with: #selector(injected(_:)))
-
+    #if DEBUG
+      Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection10.bundle")?.load()
+    #endif
+    loadApplication()
     versionController.delegate = self
     checkForNewVersion(nil)
   }
@@ -57,8 +57,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, VersionControllerDelegate {
 
   // MARK: - Injection
 
-  @objc open func injected(_ notification: Notification) {
-    guard Injection.objectWasInjected(self, in: notification) else { return }
+  @objc func injected() {
     loadApplication()
   }
 

--- a/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/Logic/ApplicationsLogicController.swift
@@ -6,6 +6,7 @@ class ApplicationsLogicController {
 
   enum PlistKey: String {
     case bundleName = "CFBundleName"
+    case executableName = "CFBundleExecutable"
     case iconFile = "CFBundleIconFile"
     case bundleIdentifier = "CFBundleIdentifier"
     case applicationIsAgent = "LSUIElement"
@@ -160,7 +161,7 @@ class ApplicationsLogicController {
       guard FileManager.default.fileExists(atPath: infoPath),
         let plist = NSDictionary.init(contentsOfFile: infoPath),
         let bundleIdentifier = plist.value(forPlistKey: .bundleIdentifier),
-        let bundleName = plist.value(forPlistKey: .bundleName),
+        let bundleName = plist.value(forPlistKey: .bundleName) ?? plist.value(forPlistKey: .executableName),
         !addedApplicationNames.contains(bundleName),
         !excludedBundles.contains(bundleIdentifier) else { continue }
 


### PR DESCRIPTION
Some applications don't have a bundle name in their property list, that would mean that they don't show up in the list of applications. To work around this issue, the executable name will be used as bundle name if it is not declared in the property list.

Fixes #60 