### PR TITLE
Implement loading screen for parsing applications

### DIFF
--- a/Gray.xcodeproj/project.pbxproj
+++ b/Gray.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		BDB20F262167A64100A72623 /* Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB20F252167A64100A72623 /* Toolbar.swift */; };
 		BDB20F292167A73C00A72623 /* SearchToolbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB20F282167A73C00A72623 /* SearchToolbarItem.swift */; };
 		BDB20F2B2167A9DB00A72623 /* SearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB20F2A2167A9DB00A72623 /* SearchField.swift */; };
+		BDBFB09421D0DDB20086F697 /* ApplicationsLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBFB09321D0DDB20086F697 /* ApplicationsLoadingViewController.swift */; };
 		BDC14C6F21B4502900610983 /* AlertsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC14C6E21B4502900610983 /* AlertsController.swift */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +67,7 @@
 		BDB20F252167A64100A72623 /* Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toolbar.swift; sourceTree = "<group>"; };
 		BDB20F282167A73C00A72623 /* SearchToolbarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToolbarItem.swift; sourceTree = "<group>"; };
 		BDB20F2A2167A9DB00A72623 /* SearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchField.swift; sourceTree = "<group>"; };
+		BDBFB09321D0DDB20086F697 /* ApplicationsLoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsLoadingViewController.swift; sourceTree = "<group>"; };
 		BDC14C6E21B4502900610983 /* AlertsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertsController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -199,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				BD9D3D7E215C30B000233333 /* ApplicationsViewController.swift */,
+				BDBFB09321D0DDB20086F697 /* ApplicationsLoadingViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -451,6 +454,7 @@
 				BD750FDC215C1AC60024E70A /* Application.swift in Sources */,
 				BDAAC48E2168EC2B0093B27D /* LayoutFactory.swift in Sources */,
 				BD9D3D7B215C2D5C00233333 /* ApplicationsDataSource.swift in Sources */,
+				BDBFB09421D0DDB20086F697 /* ApplicationsLoadingViewController.swift in Sources */,
 				BD1BA9BE215E68840052633B /* IconController.swift in Sources */,
 				BD67CE1C215BF4FE00216FDB /* MainContainerViewController.swift in Sources */,
 				BD67CE0E215BF15F00216FDB /* AppDelegate.swift in Sources */,

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Blueprints (0.8.4)
   - Differific (0.5.2)
-  - Family (0.9.5)
+  - Family (0.11.3)
   - UserInterface (0.5.0)
 
 DEPENDENCIES:
@@ -20,7 +20,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Blueprints: 6b07082216d03cbb2024988a028641425b361150
   Differific: b26ecab6daa1a2a93efeee41cec5e9593ced09bc
-  Family: 31a06f016c0d20a2fe7b163923def91cb6661d1a
+  Family: 27ac492dc902d8fb3487014377216ba41f2f8029
   UserInterface: 54e15db9aceaec2b9686d00f471adb15d2598ea3
 
 PODFILE CHECKSUM: 1923f1efa89392b6a022c0b1d5e0ea7a00317602

--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -35,10 +35,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let contentViewController = MainContainerViewController(iconStore: dependencyContainer)
     let toolbar = Toolbar(identifier: .init("MainApplicationWindowToolbar"))
     toolbar.searchDelegate = contentViewController
-    let windowSize = CGSize(width: 420, height: 640)
+    let windowSize = CGSize(width: 400, height: 640)
     let window = NSWindow(contentViewController: contentViewController)
     window.setFrameAutosaveName(NSWindow.FrameAutosaveName.init("MainApplicationWindow"))
-    window.styleMask = [.closable, .miniaturizable, .titled,
+    window.styleMask = [.closable, .miniaturizable, .resizable, .titled,
                         .fullSizeContentView, .unifiedTitleAndToolbar]
     window.titleVisibility = .hidden
     window.toolbar = toolbar
@@ -55,7 +55,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     window.minSize = windowSize
-    window.maxSize = windowSize
+    window.resizeIncrements = .init(width: 120 + 10, height: 1)
     window.setFrame(NSRect.init(origin: window.frame.origin, size: windowSize), display: true)
     window.makeKeyAndOrderFront(nil)
     self.window = window

--- a/Sources/Application/LayoutFactory.swift
+++ b/Sources/Application/LayoutFactory.swift
@@ -5,9 +5,9 @@ class LayoutFactory {
   func createGridLayout() -> VerticalBlueprintLayout {
     let layout = VerticalBlueprintLayout(
       itemSize: .init(width: 120, height: 120),
-      minimumInteritemSpacing: 12,
-      minimumLineSpacing: 12,
-      sectionInset: .init(top: 0, left: 18, bottom: 20, right: 18),
+      minimumInteritemSpacing: 10,
+      minimumLineSpacing: 10,
+      sectionInset: .init(top: 0, left: 10, bottom: 20, right: 10),
       animator: DefaultLayoutAnimator(animation: .fade))
     return layout
   }

--- a/Sources/Features/Applications/View Controllers/ApplicationsLoadingViewController.swift
+++ b/Sources/Features/Applications/View Controllers/ApplicationsLoadingViewController.swift
@@ -1,0 +1,51 @@
+import Cocoa
+import UserInterface
+
+class ApplicationsLoadingViewController: NSViewController {
+  override func loadView() { view = baseView }
+  lazy var baseView = NSView()
+  lazy var textField = NSTextField()
+  lazy var progress = NSProgressIndicator()
+
+  init(text: String) {
+    super.init(nibName: nil, bundle: nil)
+    self.textField.stringValue = text
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.addSubviews(textField, progress)
+    NSLayoutConstraint.constrain(
+      textField.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 100),
+      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -100),
+      progress.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      progress.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 100),
+      progress.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -100),
+      progress.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: 20),
+      progress.heightAnchor.constraint(equalToConstant: 10)
+    )
+    textField.maximumNumberOfLines = -1
+    textField.alignment = .center
+    textField.isBezeled = false
+    textField.isBordered = false
+    textField.isEditable = false
+    textField.isSelectable = false
+    textField.drawsBackground = false
+    textField.font = NSFont.systemFont(ofSize: 15)
+    progress.canDrawConcurrently = true
+    progress.isIndeterminate = false
+//    progress.controlTint = NSControlTint.blueControlTint
+    progress.style = .bar
+    progress.doubleValue = 0.0
+//    progress.isBezeled = true
+  }
+
+  func setText(_ text: String) {
+    self.textField.stringValue = text
+  }
+}

--- a/Sources/Features/Applications/View Controllers/ApplicationsViewController.swift
+++ b/Sources/Features/Applications/View Controllers/ApplicationsViewController.swift
@@ -4,12 +4,19 @@ import UserInterface
 
 protocol ApplicationsViewControllerDelegate: class {
   func applicationViewController(_ controller: ApplicationsViewController,
+                                 finishedLoading: Bool)
+  func applicationViewController(_ controller: ApplicationsViewController,
+                                 didLoad application: Application,
+                                 offset: Int,
+                                 total: Int)
+  func applicationViewController(_ controller: ApplicationsViewController,
                                  toggleAppearance newAppearance: Application.Appearance,
                                  application: Application)
 }
 
 class ApplicationsViewController: NSViewController, NSCollectionViewDelegate, ApplicationGridViewDelegate {
   enum State {
+    case loading(application: Application, offset: Int, total: Int)
     case view([Application])
   }
 
@@ -64,7 +71,10 @@ class ApplicationsViewController: NSViewController, NSCollectionViewDelegate, Ap
 
   private func render(_ newState: State) {
     switch newState {
+    case .loading(let application, let offset, let total):
+      delegate?.applicationViewController(self, didLoad: application, offset: offset, total: total)
     case .view(let applications):
+      delegate?.applicationViewController(self, finishedLoading: true)
       applicationCache = applications
       dataSource.reload(collectionView,
                         with: applications) { [weak self] in

--- a/Sources/Features/Applications/Views/ApplicationGridView.swift
+++ b/Sources/Features/Applications/Views/ApplicationGridView.swift
@@ -98,7 +98,7 @@ class ApplicationGridView: NSCollectionViewItem {
           titleLabel.animator().textColor = .black
           subtitleLabel.animator().textColor = .controlAccentColor
           view.layer?.borderColor = NSColor.gray.withAlphaComponent(0.25).cgColor
-          view.layer?.borderWidth = 1.5
+          view.layer?.borderWidth = 0
         }
       }, completionHandler:{
         handler?()
@@ -115,7 +115,7 @@ class ApplicationGridView: NSCollectionViewItem {
         titleLabel.textColor = .black
         subtitleLabel.textColor = .controlAccentColor
         view.layer?.borderColor = NSColor.gray.withAlphaComponent(0.25).cgColor
-        view.layer?.borderWidth = 1.5
+        view.layer?.borderWidth = 0
       case .system:
         switch view.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) {
         case .darkAqua?:
@@ -128,7 +128,7 @@ class ApplicationGridView: NSCollectionViewItem {
           titleLabel.textColor = .black
           subtitleLabel.textColor = .controlAccentColor
           view.layer?.borderColor = NSColor.gray.withAlphaComponent(0.25).cgColor
-          view.layer?.borderWidth = 1.5
+          view.layer?.borderWidth = 0
         default:
           break
         }

--- a/Sources/Features/Main/MainContainerViewController.swift
+++ b/Sources/Features/Main/MainContainerViewController.swift
@@ -5,9 +5,9 @@ class MainContainerViewController: FamilyViewController,
   ApplicationsViewControllerDelegate,
   SystemPreferenceViewControllerDelegate,
   ToolbarSearchDelegate {
-
   lazy var systemLabelController = LabelViewController(text: "System preferences")
   lazy var applicationLabelController = LabelViewController(text: "Applications")
+  lazy var loadingLabelController = ApplicationsLoadingViewController(text: "Loading...")
   let preferencesViewController: SystemPreferenceViewController
   let applicationsViewController: ApplicationsViewController
 
@@ -33,10 +33,14 @@ class MainContainerViewController: FamilyViewController,
     addChild(systemLabelController, height: 60)
     addChild(preferencesViewController, view: { $0.collectionView })
     addChild(applicationLabelController, height: 60)
+    addChild(loadingLabelController)
     addChild(applicationsViewController, view: { $0.collectionView })
+
+    loadingLabelController.view.frame.size.height = 60 + 120 + 120 + 20 + scrollView.contentInsets.top
 
     systemLabelController.view.enclosingScrollView?.drawsBackground = true
     applicationLabelController.view.enclosingScrollView?.drawsBackground = true
+    loadingLabelController.view.enclosingScrollView?.drawsBackground = true
   }
 
   override func viewDidAppear() {
@@ -66,6 +70,17 @@ class MainContainerViewController: FamilyViewController,
   }
 
   // MARK: - ApplicationCollectionViewControllerDelegate
+
+  func applicationViewController(_ controller: ApplicationsViewController, finishedLoading: Bool) {
+    loadingLabelController.view.alphaValue = 0.0
+  }
+
+  func applicationViewController(_ controller: ApplicationsViewController,
+                                 didLoad application: Application, offset: Int, total: Int) {
+    let progress = Double(offset + 1) / Double(total) * Double(100)
+    loadingLabelController.progress.doubleValue = floor(progress)
+    loadingLabelController.textField.stringValue = "Loading (\(offset)/\(total)): \(application.name)"
+  }
 
   func applicationViewController(_ controller: ApplicationsViewController,
                                  toggleAppearance newAppearance: Application.Appearance,

--- a/Sources/Shared/LabelViewController.swift
+++ b/Sources/Shared/LabelViewController.swift
@@ -20,8 +20,8 @@ class LabelViewController: NSViewController {
     view.addSubview(textField)
     NSLayoutConstraint.constrain(
       textField.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
+      textField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15),
+      textField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15)
     )
     textField.isBezeled = false
     textField.isBordered = false


### PR DESCRIPTION
- The window can now be resized with `resizeIncrements` on `NSWindow`
- Updates to a new version of `Family` (0.11.3) 
- Implements a loading screen that is displayed when `Gray` is parsing applications (you probably won't see this screen, see screenshot).
- Minor GUI tweaks to layout sizes.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/57446/50422227-f1dd7200-0848-11e9-8af1-6444308fac42.png">