### PR TITLE
Feature image caching

### DIFF
--- a/Sources/Features/Applications/Views/ApplicationGridView.swift
+++ b/Sources/Features/Applications/Views/ApplicationGridView.swift
@@ -115,7 +115,7 @@ class ApplicationGridView: NSCollectionViewItem {
         titleLabel.textColor = .black
         subtitleLabel.textColor = .controlAccentColor
         view.layer?.borderColor = NSColor.gray.withAlphaComponent(0.25).cgColor
-        view.layer?.borderWidth = 0
+        view.layer?.borderWidth = 1.0
       case .system:
         switch view.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) {
         case .darkAqua?:
@@ -128,7 +128,7 @@ class ApplicationGridView: NSCollectionViewItem {
           titleLabel.textColor = .black
           subtitleLabel.textColor = .controlAccentColor
           view.layer?.borderColor = NSColor.gray.withAlphaComponent(0.25).cgColor
-          view.layer?.borderWidth = 0
+          view.layer?.borderWidth = 1.0
         default:
           break
         }

--- a/Sources/Features/SystemPreferences/Views/SystemPreferenceView.swift
+++ b/Sources/Features/SystemPreferences/Views/SystemPreferenceView.swift
@@ -19,7 +19,7 @@ class SystemPreferenceView: NSCollectionViewItem {
 
     view.layer?.backgroundColor = NSColor.white.cgColor
     view.layer?.borderColor = NSColor.gray.withAlphaComponent(0.25).cgColor
-    view.layer?.borderWidth = 1.5
+    view.layer?.borderWidth = 1.0
     view.layer?.cornerRadius = 20
     view.layer?.masksToBounds = true
 


### PR DESCRIPTION
- Improves performance by reducing the size of the icons used in the application, the processed icon is then saved to disk and reused across application launches.
- Improves scrolling performance because there is less heavy lifting when processing images.
- Adds missing border on application cell.