### PR TITLE
Remove setting the frame

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -56,7 +56,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     window.minSize = windowSize
     window.resizeIncrements = .init(width: 120 + 10, height: 1)
-    window.setFrame(NSRect.init(origin: window.frame.origin, size: windowSize), display: true)
     window.makeKeyAndOrderFront(nil)
     self.window = window
     self.toolbar = toolbar


### PR DESCRIPTION
By removing this line, the application will remember the last size that the user had. It makes sense to not reset the size now that the window accepts resizing.