### PR TITLE
Add initial support for localized app names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.3
+osx_image: xcode11
 language: objective-c
 
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '~> 1.6.0.beta.2'
+gem 'cocoapods', '~> 1.9.1'

--- a/Gray.xcodeproj/project.pbxproj
+++ b/Gray.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.16.0;
+				MARKETING_VERSION = 0.16.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zenangst.Gray;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -745,7 +745,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.16.0;
+				MARKETING_VERSION = 0.16.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zenangst.Gray;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Gray.xcodeproj/project.pbxproj
+++ b/Gray.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.15.0;
+				MARKETING_VERSION = 0.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zenangst.Gray;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -745,7 +745,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.15.0;
+				MARKETING_VERSION = 0.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zenangst.Gray;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :macos, '10.14'
 
 # Frameworks
-pod 'Blueprints', git: 'git@github.com:zenangst/Blueprints.git', branch: 'feature/preferred-layout-attributes'
+pod 'Blueprints', git: 'https://github.com/zenangst/Blueprints.git', branch: 'feature/preferred-layout-attributes'
 pod 'Differific'
 pod 'Family'
 pod 'UserInterface'

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :macos, '10.14'
 
 # Frameworks
-pod 'Blueprints'
+pod 'Blueprints', git: 'git@github.com:zenangst/Blueprints.git', branch: 'feature/preferred-layout-attributes'
 pod 'Differific'
 pod 'Family'
 pod 'UserInterface'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - Blueprints (0.13.1)
   - Differific (0.8.2)
-  - Family (0.22.10)
+  - Family (0.22.11)
   - Sourcery (0.17.0)
   - UserInterface (0.5.0)
 
 DEPENDENCIES:
-  - Blueprints
+  - "Blueprints (from `git@github.com:zenangst/Blueprints.git`, branch `feature/preferred-layout-attributes`)"
   - Differific
   - Family
   - Sourcery
@@ -14,19 +14,28 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - Blueprints
     - Differific
     - Family
     - Sourcery
     - UserInterface
 
+EXTERNAL SOURCES:
+  Blueprints:
+    :branch: feature/preferred-layout-attributes
+    :git: "git@github.com:zenangst/Blueprints.git"
+
+CHECKOUT OPTIONS:
+  Blueprints:
+    :commit: 6719ed1aba5cfca311ae04d1035832755116dfc0
+    :git: "git@github.com:zenangst/Blueprints.git"
+
 SPEC CHECKSUMS:
   Blueprints: ddd6ab1e455c98471aaef2fdd0b09b5f9b53af5b
   Differific: c3840b9e4d1ee2216b2c0054c270e4a616df9327
-  Family: 96e3177a03a5ff76a26c13c41bdf19fee14f9efb
+  Family: d380fa14141faf72359813338ee64ef93920f326
   Sourcery: 3ed61be7c8a1218fce349266139379dba477efe0
   UserInterface: 54e15db9aceaec2b9686d00f471adb15d2598ea3
 
-PODFILE CHECKSUM: 9a4a4208e8595d7fa51cbc758521284dec9359cc
+PODFILE CHECKSUM: 2c8c2d81b994943738c4544119e5d29b6bb5f0fe
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - UserInterface
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs:
+  https://github.com/CocoaPods/Specs.git:
     - Blueprints
     - Differific
     - Family

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Blueprints (0.13.1)
   - Differific (0.8.2)
-  - Family (0.22.4)
+  - Family (0.22.10)
   - Sourcery (0.17.0)
   - UserInterface (0.5.0)
 
@@ -23,10 +23,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Blueprints: ddd6ab1e455c98471aaef2fdd0b09b5f9b53af5b
   Differific: c3840b9e4d1ee2216b2c0054c270e4a616df9327
-  Family: 0dffb3c3ec36b85a599e43b9aa3d8cefeef81873
+  Family: 96e3177a03a5ff76a26c13c41bdf19fee14f9efb
   Sourcery: 3ed61be7c8a1218fce349266139379dba477efe0
   UserInterface: 54e15db9aceaec2b9686d00f471adb15d2598ea3
 
 PODFILE CHECKSUM: 9a4a4208e8595d7fa51cbc758521284dec9359cc
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.9.1

--- a/Resources/Base.lproj/MainMenu.xib
+++ b/Resources/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -83,6 +83,18 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="Edit" id="RkH-bv-tyt">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Edit" id="xHZ-GJ-NC7">
+                        <items>
+                            <menuItem title="Find" keyEquivalent="f" id="I8X-fE-RoM">
+                                <connections>
+                                    <action selector="search:" target="-1" id="Ngs-CP-v6F"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
                 <menuItem title="View" id="H8h-7b-M4v">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="View" id="HyV-fh-RgO">
@@ -110,7 +122,7 @@
                                     <action selector="switchToList:" target="Voe-Tx-rLC" id="X1I-lU-zXV"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Enter Full Screen" keyEquivalent="↩" id="4J7-dP-txa">
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="toggleFullScreen:" target="-1" id="dU3-MA-1Rq"/>
@@ -128,8 +140,8 @@
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Zoom" id="R4o-n2-Eq4">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Zoom" keyEquivalent="f" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
                                 </connections>
@@ -158,6 +170,20 @@
                 </menuItem>
             </items>
             <point key="canvasLocation" x="102" y="227"/>
+        </menu>
+        <menu id="LDQ-su-H2T">
+            <items>
+                <menuItem title="Item 1" id="enw-At-piT">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                </menuItem>
+                <menuItem title="Item 2" id="x29-PV-jIz">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                </menuItem>
+                <menuItem title="Item 3" id="K0C-Im-LAa">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                </menuItem>
+            </items>
+            <point key="canvasLocation" x="140" y="120"/>
         </menu>
     </objects>
 </document>

--- a/Resources/Base.lproj/MainMenu.xib
+++ b/Resources/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -78,6 +78,12 @@
                             <menuItem title="Import" keyEquivalent="o" id="KaW-ft-85H">
                                 <connections>
                                     <action selector="importAction:" target="Voe-Tx-rLC" id="ODr-UG-1fv"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="WVG-bW-ENt"/>
+                            <menuItem title="Close Window" keyEquivalent="w" id="HEn-2t-aJ4">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="Ag9-Ec-9I2"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Sources/Features/Applications/Application.swift
+++ b/Sources/Features/Applications/Application.swift
@@ -14,4 +14,5 @@ struct Application: Hashable {
   let preferencesUrl: URL
   let appearance: Appearance
   let restricted: Bool
+  var localizedName: String?
 }

--- a/Sources/Features/Applications/ApplicationGridView.swift
+++ b/Sources/Features/Applications/ApplicationGridView.swift
@@ -15,7 +15,7 @@ class ApplicationGridView: NSCollectionViewItem, CollectionViewItemComponent, Ap
 
   // sourcery: $RawBinding = "iconStore.loadIcon(for: model.application) { image in view.iconView.image = image }"
   lazy var iconView = NSImageView()
-  // sourcery: let title: String = "titleLabel.stringValue = model.title"
+  // sourcery: let title: String = "titleLabel.stringValue = model.application.localizedName ?? model.title"
   lazy var titleLabel = NSTextField()
   // sourcery: let subtitle: String = "subtitleLabel.stringValue = model.subtitle"
   lazy var subtitleLabel = NSTextField()

--- a/Sources/Features/Applications/ApplicationListView.swift
+++ b/Sources/Features/Applications/ApplicationListView.swift
@@ -14,7 +14,7 @@ class ApplicationListView: NSCollectionViewItem, CollectionViewItemComponent, Ap
 
   // sourcery: $RawBinding = "iconStore.loadIcon(for: model.application) { image in view.iconView.image = image }"
   lazy var iconView: NSImageView = .init()
-  // sourcery: let title: String = "titleLabel.stringValue = model.title"
+  // sourcery: let title: String = "titleLabel.stringValue = model.application.localizedName ?? model.title"
   lazy var titleLabel: NSTextField = .init()
   // sourcery: let subtitle: String = "subtitleLabel.stringValue = model.subtitle"
   lazy var subtitleLabel: NSTextField = .init()

--- a/Sources/Features/Applications/ApplicationsFeatureViewController.swift
+++ b/Sources/Features/Applications/ApplicationsFeatureViewController.swift
@@ -113,7 +113,9 @@ ApplicationGridViewDelegate, ApplicationsLogicControllerDelegate, ApplicationLis
     case 0:
       filtered = applicationCache
     default:
-      filtered = applicationCache.filter({ $0.name.lowercased().contains(query) })
+      filtered = applicationCache.filter({
+        return ($0.localizedName ?? $0.name).lowercased().contains(query)
+      })
     }
 
     switch mode {

--- a/Sources/Features/Applications/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/ApplicationsLogicController.swift
@@ -210,12 +210,24 @@ class ApplicationsLogicController {
         metadata = "🔐 Locked".localized
       }
 
-      let application = Application(bundleIdentifier: bundleIdentifier,
+      var application = Application(bundleIdentifier: bundleIdentifier,
                                     name: bundleName, metadata: metadata,
                                     url: url,
                                     preferencesUrl: resolvedAppPreferenceUrl,
                                     appearance: appearance,
                                     restricted: restricted)
+
+      if var preferredLanguage = NSLocale.preferredLanguages.first {
+        if preferredLanguage.contains("en-") {
+          preferredLanguage = "en"
+        }
+
+        let infoPlistPath = url.appendingPathComponent("Contents/Resources/zh-Hans.lproj/InfoPlist.strings")
+        if FileManager.default.fileExists(atPath: infoPlistPath.path),
+          let dictionary = NSDictionary(contentsOfFile: infoPlistPath.path) as? [String: String] {
+          application.localizedName = dictionary["CFBundleName"]
+        }
+      }
 
       DispatchQueue.main.async { [weak self] in
         guard let strongSelf = self else { return }

--- a/Sources/Features/Applications/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/ApplicationsLogicController.swift
@@ -217,13 +217,7 @@ class ApplicationsLogicController {
                                     appearance: appearance,
                                     restricted: restricted)
 
-      if let preferredLanguage = Locale.current.languageCode {
-        let infoPlistPath = url.appendingPathComponent("Contents/Resources/\(preferredLanguage).lproj/InfoPlist.strings")
-        if FileManager.default.fileExists(atPath: infoPlistPath.path),
-          let dictionary = NSDictionary(contentsOfFile: infoPlistPath.path) as? [String: String] {
-          application.localizedName = dictionary["CFBundleName"]
-        }
-      }
+      application.localizedName = FileManager.default.displayName(atPath: application.url.path)
 
       DispatchQueue.main.async { [weak self] in
         guard let strongSelf = self else { return }

--- a/Sources/Features/Applications/ApplicationsLogicController.swift
+++ b/Sources/Features/Applications/ApplicationsLogicController.swift
@@ -217,12 +217,8 @@ class ApplicationsLogicController {
                                     appearance: appearance,
                                     restricted: restricted)
 
-      if var preferredLanguage = NSLocale.preferredLanguages.first {
-        if preferredLanguage.contains("en-") {
-          preferredLanguage = "en"
-        }
-
-        let infoPlistPath = url.appendingPathComponent("Contents/Resources/zh-Hans.lproj/InfoPlist.strings")
+      if let preferredLanguage = Locale.current.languageCode {
+        let infoPlistPath = url.appendingPathComponent("Contents/Resources/\(preferredLanguage).lproj/InfoPlist.strings")
         if FileManager.default.fileExists(atPath: infoPlistPath.path),
           let dictionary = NSDictionary(contentsOfFile: infoPlistPath.path) as? [String: String] {
           application.localizedName = dictionary["CFBundleName"]

--- a/Voodoo/Output/CollectionViewItemComponent-macOS.generated.swift
+++ b/Voodoo/Output/CollectionViewItemComponent-macOS.generated.swift
@@ -124,7 +124,7 @@ class ApplicationGridDataSource: NSObject, NSCollectionViewDataSource {
     if let view = item as? ApplicationGridView {
       view.currentAppearance = model.application.appearance
       iconStore.loadIcon(for: model.application) { image in view.iconView.image = image }
-      view.titleLabel.stringValue = model.title
+      view.titleLabel.stringValue = model.application.localizedName ?? model.title
       view.subtitleLabel.stringValue = model.subtitle
     }
 
@@ -258,7 +258,7 @@ class ApplicationListDataSource: NSObject, NSCollectionViewDataSource {
     if let view = item as? ApplicationListView {
       view.currentAppearance = model.application.appearance
       iconStore.loadIcon(for: model.application) { image in view.iconView.image = image }
-      view.titleLabel.stringValue = model.title
+      view.titleLabel.stringValue = model.application.localizedName ?? model.title
       view.subtitleLabel.stringValue = model.subtitle
     }
 


### PR DESCRIPTION
The application logic controller will now try and resolve a localized name
for the application rather than using the executable name.